### PR TITLE
ci: streamline GitHub release workflows

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: Release PR
 
 on:
   push:
@@ -12,12 +12,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Tag name to release"
+        description: "Tag to package (e.g. 1.4.3)"
         required: true
         type: string
 
@@ -16,25 +16,32 @@ permissions:
 
 jobs:
   package:
+    name: Package and Upload
     runs-on: ubuntu-latest
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Resolve tag
-        id: tag
+        id: resolve
+        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ github.event.inputs.tag_name }}"
           else
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ github.ref_name }}"
           fi
+          echo "TAG_NAME=$TAG" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v5
+      - name: Checkout tag
+        uses: actions/checkout@v5
         with:
-          ref: ${{ steps.tag.outputs.tag }}
+          ref: refs/tags/${{ env.TAG_NAME }}
+          fetch-depth: 0
 
-      - uses: BigWigsMods/packager@v2
-        with:
-          args: -g ${{ steps.tag.outputs.tag }}
+      - name: Package and upload
+        uses: BigWigsMods/packager@v2
         env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REF: refs/tags/${{ env.TAG_NAME }}
+          


### PR DESCRIPTION
## Summary

- **release-pr.yml**: Simplify release-please config by removing explicit output mapping, step ID, and config/manifest file references (defaults are auto-detected)
- **release.yml**: Clean up the packaging workflow with clearer naming, move secrets to job-level `env`, use `GITHUB_ENV` instead of step outputs for tag resolution, and ensure proper `refs/tags/` prefix on checkout

Reduces workflow boilerplate while preserving the same release-please + BigWigsMods/packager pipeline behavior.