### PR TITLE
docs: touch up README with accurate details and consistent formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 [![Luacheck](https://img.shields.io/github/actions/workflow/status/Xerrion/PhDamage/lint.yml?label=luacheck&style=flat-square)](https://github.com/Xerrion/PhDamage/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](LICENSE)
 
-Expected damage and healing calculator for World of Warcraft — TBC Anniversary.
+Expected damage and healing calculator for World of Warcraft -- TBC Anniversary.
 
 ## Overview
 
-PhDamage computes and displays expected damage and healing values on spell tooltips and action bar buttons. Calculations are based on your current talents, gear, buffs, and debuffs — updated in real time as your character state changes.
+PhDamage computes and displays expected damage and healing values on spell tooltips and action bar buttons. "Expected" means the average outcome after accounting for hit chance and crit chance, so you see the true per-cast value rather than raw base damage. Calculations are based on your current talents, gear, buffs, and debuffs -- updated in real time as your character state changes.
 
 ## Features
 
-- **All 9 classes supported** — Warlock, Hunter, Mage, Priest, Warrior, Rogue, Druid, Shaman, Paladin
-- **Real-time calculations** — Automatically updates when talents, gear, or buffs change
-- **Tooltip integration** — School-colored damage/healing values displayed in spell tooltips
-- **Action bar overlays** — Expected damage shown directly on action bar buttons
-- **1100+ unit tests** — Comprehensive test coverage ensuring calculation accuracy
+- **All 9 classes supported** -- Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior
+- **Real-time calculations** -- Automatically updates when talents, gear, or buffs change
+- **Tooltip integration** -- School-colored damage/healing values displayed in a companion tooltip frame
+- **Action bar overlays** -- Expected damage shown directly on action bar buttons
+- **1,000+ unit tests** -- Comprehensive test coverage ensuring calculation accuracy
 
 ## Supported Versions
 
@@ -31,7 +31,7 @@ PhDamage follows a strict 4-layer architecture where the engine layer is pure Lu
 | Layer | Directory | Purpose |
 |-------|-----------|---------|
 | Shell | `Core/` | WoW API interaction, event handling, state collection |
-| Engine | `Engine/` | Pure Lua calculation pipeline — no WoW API calls |
+| Engine | `Engine/` | Pure Lua calculation pipeline -- no WoW API calls |
 | Data | `Data/` | Declarative spell, talent, and aura descriptor tables |
 | Presentation | `Presentation/` | Tooltip rendering and action bar overlays |
 
@@ -48,6 +48,8 @@ PhDamage follows a strict 4-layer architecture where the engine layer is pure Lu
 
 ## Installation
 
+### Manual
+
 1. Download the latest release from [GitHub Releases](https://github.com/Xerrion/PhDamage/releases)
 2. Extract to your `Interface/AddOns/` directory
 3. Restart WoW or `/reload`
@@ -56,19 +58,23 @@ PhDamage follows a strict 4-layer architecture where the engine layer is pure Lu
 
 | Command | Description |
 |---------|-------------|
-| `/phd` | Show diagnostic information |
+| `/phd` | Show diagnostic information for all spells |
+| `/phd state` | Show current player state snapshot |
+| `/phd spell <name>` | Detailed breakdown for a specific spell |
 | `/phd help` | List available commands |
+
+`/phdamage` works as an alias for `/phd`.
 
 ## Dependencies
 
-- [Ace3](https://www.wowace.com/projects/ace3) — bundled automatically via `.pkgmeta`
+- [Ace3](https://www.wowace.com/projects/ace3) -- bundled automatically via `.pkgmeta`
 
 ## Development
 
 ### Prerequisites
 
-- [Luacheck](https://github.com/mpeterv/luacheck) — static analysis
-- [Busted](https://olivinelabs.com/busted/) — unit testing framework
+- [Luacheck](https://github.com/mpeterv/luacheck) -- static analysis
+- [Busted](https://olivinelabs.com/busted/) -- unit testing framework
 
 ### Running Tests
 


### PR DESCRIPTION
## Summary

- Clarify what "expected" damage means (accounts for hit/crit chance) in the Overview section
- Fix test count from "1100+" to "1,000+" to match actual count (1088)
- Document all slash commands (`/phd state`, `/phd spell <name>`) and the `/phdamage` alias
- Alphabetize the class list for consistency
- Note that tooltip uses a companion frame, not inline display
- Replace em-dashes with double hyphens per project conventions
- Add "Manual" subheading under Installation for future extensibility

This is a docs-only change and should not trigger a release-please release PR.