### PR TITLE
fix: add permissions to caller workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-pr:
     uses: Xerrion/wow-workflows/.github/workflows/release-pr.yml@main


### PR DESCRIPTION
## Summary
- Adds `contents: write` and `pull-requests: write` permissions to the release-pr caller workflow
- Reusable workflows cannot escalate permissions beyond what the caller grants, so the `permissions` block must be in the caller