### PR TITLE
feat: add AceConfig options UI for overlay positioning (#40)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -87,6 +87,8 @@ read_globals = {
     "GameTooltipText",
     "UIParent",
     "C_Timer",
+    "Settings",
+    "InterfaceOptionsFrame_OpenToCategory",
 
     -- Third-party addons (optional at runtime)
     "ElvUI",

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -35,6 +35,7 @@ local DB_DEFAULTS = {
         },
     },
 }
+ns.DB_DEFAULTS = DB_DEFAULTS
 
 -------------------------------------------------------------------------------
 -- Lifecycle: OnInitialize (runs once, before PLAYER_LOGIN)
@@ -45,6 +46,11 @@ function PhDamage:OnInitialize()
     -- Register slash commands
     self:RegisterChatCommand("phd", "OnSlashCommand")
     self:RegisterChatCommand("phdamage", "OnSlashCommand")
+
+    -- Register the AceConfig options panel
+    if ns.Options and ns.Options.Register then
+        ns.Options:Register()
+    end
 
     self:Print("PhDamage loaded. Type /phd for diagnostics.")
 end
@@ -77,95 +83,6 @@ end
 -- Slash Command Router
 -------------------------------------------------------------------------------
 
--- Valid anchor point identifiers accepted by the config command
-local VALID_ANCHORS = {
-    BOTTOM = true, TOP = true, CENTER = true,
-    LEFT = true, RIGHT = true,
-    BOTTOMLEFT = true, BOTTOMRIGHT = true,
-    TOPLEFT = true, TOPRIGHT = true,
-}
-
-local function HandleConfigCommand(addon, args)
-    local cfg = addon.db.profile.overlay
-    local setting = args[2] and strlower(args[2]) or ""
-    local value   = args[3]
-
-    if setting == "" then
-        addon:Print("Overlay settings:")
-        addon:Print(string.format("  anchor: %s", cfg.anchor))
-        addon:Print(string.format("  offsetX: %d", cfg.offsetX))
-        addon:Print(string.format("  offsetY: %d", cfg.offsetY))
-        addon:Print(string.format("  fontSize: %d", cfg.fontSize))
-        addon:Print(string.format("  abbreviate: %s", cfg.abbreviateNumbers and "on" or "off"))
-        return
-    end
-
-    if setting == "anchor" then
-        local v = value and strupper(value) or ""
-        if VALID_ANCHORS[v] then
-            cfg.anchor = v
-            addon:Print("Overlay anchor set to: " .. v)
-        else
-            addon:Print("Invalid anchor. Valid values: BOTTOM, TOP, CENTER, LEFT, RIGHT, "
-                .. "BOTTOMLEFT, BOTTOMRIGHT, TOPLEFT, TOPRIGHT")
-            return
-        end
-
-    elseif setting == "offsetx" then
-        local n = tonumber(value)
-        if n then
-            cfg.offsetX = n
-            addon:Print("Overlay offsetX set to: " .. n)
-        else
-            addon:Print("Invalid value for offsetX. Expected a number.")
-            return
-        end
-
-    elseif setting == "offsety" then
-        local n = tonumber(value)
-        if n then
-            cfg.offsetY = n
-            addon:Print("Overlay offsetY set to: " .. n)
-        else
-            addon:Print("Invalid value for offsetY. Expected a number.")
-            return
-        end
-
-    elseif setting == "fontsize" then
-        local n = tonumber(value)
-        if n and n >= 6 and n <= 24 then
-            cfg.fontSize = n
-            addon:Print("Overlay font size set to: " .. n)
-        else
-            addon:Print("Invalid font size. Expected a number between 6 and 24.")
-            return
-        end
-
-    elseif setting == "abbreviate" then
-        local v = value and strlower(value) or ""
-        if v == "on" or v == "true" or v == "1" then
-            cfg.abbreviateNumbers = true
-            addon:Print("Number abbreviation enabled.")
-        elseif v == "off" or v == "false" or v == "0" then
-            cfg.abbreviateNumbers = false
-            addon:Print("Number abbreviation disabled.")
-        else
-            addon:Print("Invalid value for abbreviate. Use 'on' or 'off'.")
-            return
-        end
-
-    else
-        addon:Print("Unknown config setting '" .. setting
-            .. "'. Valid settings: anchor, offsetX, offsetY, fontSize, abbreviate")
-        return
-    end
-
-    -- Apply the updated settings to all existing overlays
-    if ns.ActionBar and ns.ActionBar.ApplySettings then
-        ns.ActionBar.ApplySettings()
-    end
-end
-
 function PhDamage:OnSlashCommand(input)
     if not ns.Diagnostics then
         self:Print("Diagnostics module not loaded.")
@@ -182,19 +99,18 @@ function PhDamage:OnSlashCommand(input)
         local linkName = spellInput:match("|Hspell:%d+.-|h%[(.-)%]|h")
         ns.Diagnostics.PrintSpell(linkName or spellInput)
     elseif cmd == "config" then
-        HandleConfigCommand(self, args)
+        if ns.Options and ns.Options.Open then
+            ns.Options:Open()
+        else
+            self:Print("Options module not loaded.")
+        end
     elseif cmd == "help" then
         self:Print("Usage:")
-        self:Print("  /phd — Show all spell computations")
-        self:Print("  /phd state — Show current player state snapshot")
-        self:Print("  /phd spell <name> — Detailed breakdown for one spell")
-        self:Print("  /phd config — Show overlay display settings")
-        self:Print("  /phd config anchor <point> — Set text anchor (BOTTOM, TOP, CENTER, ...)")
-        self:Print("  /phd config offsetX <n> — Set horizontal offset (default 0)")
-        self:Print("  /phd config offsetY <n> — Set vertical offset (default 2)")
-        self:Print("  /phd config fontSize <n> — Set font size 6-24 (default 10)")
-        self:Print("  /phd config abbreviate on|off — Toggle k/M number shortening (default on)")
-        self:Print("  /phd help — Show this help")
+        self:Print("  /phd - Show all spell computations")
+        self:Print("  /phd state - Show current player state snapshot")
+        self:Print("  /phd spell <name> - Detailed breakdown for one spell")
+        self:Print("  /phd config - Open the overlay options panel")
+        self:Print("  /phd help - Show this help")
     else
         ns.Diagnostics.PrintAll()
     end

--- a/Core/Options.lua
+++ b/Core/Options.lua
@@ -1,0 +1,173 @@
+-------------------------------------------------------------------------------
+-- Options.lua
+-- AceConfig-3.0 options panel bound to db.profile.overlay
+--
+-- Supported versions: TBC Anniversary
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached globals
+-------------------------------------------------------------------------------
+local LibStub = LibStub
+local Settings = Settings
+local InterfaceOptionsFrame_OpenToCategory = InterfaceOptionsFrame_OpenToCategory
+local pairs = pairs
+
+-------------------------------------------------------------------------------
+-- Module
+-------------------------------------------------------------------------------
+local Options = {}
+ns.Options = Options
+
+-------------------------------------------------------------------------------
+-- Anchor choice list (also drives the dropdown values)
+-------------------------------------------------------------------------------
+local ANCHOR_VALUES = {
+    TOPLEFT     = "TOPLEFT",
+    TOP         = "TOP",
+    TOPRIGHT    = "TOPRIGHT",
+    LEFT        = "LEFT",
+    CENTER      = "CENTER",
+    RIGHT       = "RIGHT",
+    BOTTOMLEFT  = "BOTTOMLEFT",
+    BOTTOM      = "BOTTOM",
+    BOTTOMRIGHT = "BOTTOMRIGHT",
+}
+
+-------------------------------------------------------------------------------
+-- Internal helpers
+-------------------------------------------------------------------------------
+local function GetOverlay()
+    return ns.Addon.db.profile.overlay
+end
+
+local function ApplyOverlay()
+    if ns.ActionBar and ns.ActionBar.ApplySettings then
+        ns.ActionBar.ApplySettings()
+    end
+end
+
+-- get/set handlers for AceConfig - info[#info] is the leaf option key
+local function GetSetting(info)
+    return GetOverlay()[info[#info]]
+end
+
+local function SetSetting(info, value)
+    GetOverlay()[info[#info]] = value
+    ApplyOverlay()
+end
+
+local function ResetToDefaults()
+    local defaults = ns.DB_DEFAULTS and ns.DB_DEFAULTS.profile and ns.DB_DEFAULTS.profile.overlay
+    if not defaults then return end
+
+    local overlay = GetOverlay()
+    for key, value in pairs(defaults) do
+        overlay[key] = value
+    end
+    ApplyOverlay()
+end
+
+-------------------------------------------------------------------------------
+-- BuildOptionsTable() - returns the AceConfig schema
+-------------------------------------------------------------------------------
+function Options:BuildOptionsTable()
+    return {
+        type = "group",
+        name = "PhDamage",
+        get  = GetSetting,
+        set  = SetSetting,
+        args = {
+            overlayHeader = {
+                type  = "header",
+                name  = "Action Bar Overlay",
+                order = 1,
+            },
+            anchor = {
+                type   = "select",
+                name   = "Anchor",
+                desc   = "Anchor point on the action button where the damage text is placed.",
+                values = ANCHOR_VALUES,
+                order  = 10,
+            },
+            offsetX = {
+                type  = "range",
+                name  = "Horizontal Offset",
+                desc  = "Horizontal pixel offset from the anchor point.",
+                min   = -50,
+                max   = 50,
+                step  = 1,
+                order = 20,
+            },
+            offsetY = {
+                type  = "range",
+                name  = "Vertical Offset",
+                desc  = "Vertical pixel offset from the anchor point.",
+                min   = -50,
+                max   = 50,
+                step  = 1,
+                order = 30,
+            },
+            fontSize = {
+                type  = "range",
+                name  = "Font Size",
+                desc  = "Font size of the overlay damage text.",
+                min   = 6,
+                max   = 32,
+                step  = 1,
+                order = 40,
+            },
+            abbreviateNumbers = {
+                type  = "toggle",
+                name  = "Abbreviate Numbers",
+                desc  = "Display large numbers with k/M suffixes (e.g. 1.2k instead of 1234).",
+                order = 50,
+            },
+            spacer = {
+                type  = "description",
+                name  = " ",
+                order = 60,
+            },
+            reset = {
+                type  = "execute",
+                name  = "Reset to Defaults",
+                desc  = "Restore all overlay settings to their default values.",
+                func  = ResetToDefaults,
+                order = 70,
+            },
+        },
+    }
+end
+
+-------------------------------------------------------------------------------
+-- Register() - wires the options table into AceConfig and Blizzard panels
+-------------------------------------------------------------------------------
+function Options:Register()
+    local AceConfig = LibStub("AceConfig-3.0", true)
+    local AceConfigDialog = LibStub("AceConfigDialog-3.0", true)
+    if not AceConfig or not AceConfigDialog then return end
+
+    AceConfig:RegisterOptionsTable(ADDON_NAME, self:BuildOptionsTable())
+    self.blizFrame = AceConfigDialog:AddToBlizOptions(ADDON_NAME, "PhDamage")
+end
+
+-------------------------------------------------------------------------------
+-- Open() - opens the Blizzard interface options to the PhDamage panel
+-------------------------------------------------------------------------------
+function Options:Open()
+    local frame = self.blizFrame
+    if not frame then return end
+
+    if Settings and Settings.OpenToCategory then
+        Settings.OpenToCategory(frame.name or frame)
+        return
+    end
+
+    if InterfaceOptionsFrame_OpenToCategory then
+        -- TBC 2.5.x quirk: first call only opens the panel; second call selects it.
+        InterfaceOptionsFrame_OpenToCategory(frame)
+        InterfaceOptionsFrame_OpenToCategory(frame)
+    end
+end

--- a/Libs/embeds.xml
+++ b/Libs/embeds.xml
@@ -7,5 +7,7 @@
     <Include file="Ace3\AceConsole-3.0\AceConsole-3.0.xml"/>
     <Include file="Ace3\AceEvent-3.0\AceEvent-3.0.xml"/>
     <Include file="Ace3\AceDB-3.0\AceDB-3.0.xml"/>
+    <Include file="Ace3\AceGUI-3.0\AceGUI-3.0.xml"/>
+    <Include file="Ace3\AceConfig-3.0\AceConfig-3.0.xml"/>
 
 </Ui>

--- a/PhDamage.toc
+++ b/PhDamage.toc
@@ -16,6 +16,7 @@ Libs\embeds.xml
 # Core
 Core\Constants.lua
 Core\Init.lua
+Core\Options.lua
 Core\Events.lua
 Core\StateCollector.lua
 


### PR DESCRIPTION
## Description

Adds an AceConfig-3.0 options panel for the action-bar damage overlay, replacing the text-argument `/phd config` handler. Users get a Blizzard-integrated UI with anchor dropdown, offset/font sliders, abbreviate toggle, and reset button - no more memorizing keys and valid anchor values.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issues

Closes #40

## Testing

- [x] Luacheck passes (`luacheck .`) - 0 warnings / 0 errors across 78 files
- [ ] Tested in-game manually - pending reviewer/owner smoke test
- [ ] WoW version(s) tested on: TBC Anniversary (primary target)

In-game verification still needed:
- `/phd config` opens the panel
- Settings persist across `/reload`
- Reset button restores defaults
- Other slash subcommands (`state`, `spell`, `help`) unchanged

## Screenshots

_None yet - panel screenshots to be added after in-game smoke test._

## Changes

- New `Core/Options.lua` - AceConfig schema bound to `db.profile.overlay`; reset button uses `ns.DB_DEFAULTS`
- `Core/Init.lua` - exposes `ns.DB_DEFAULTS`, registers Options in `OnInitialize`, `/phd config` now opens the GUI, removes obsolete `VALID_ANCHORS` text-arg parser
- `PhDamage.toc` - loads `Core/Options.lua` after `Core/Init.lua`
- `Libs/embeds.xml` - includes `AceGUI-3.0.xml` and `AceConfig-3.0.xml` (Registry/Cmd/Dialog come transitively; libs were already embedded via pkgmeta external, just not loaded)
- `.luacheckrc` - adds `Settings` and `InterfaceOptionsFrame_OpenToCategory` to `read_globals`

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [ ] I have tested my changes in-game
- [x] Luacheck reports no warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a graphical options panel for overlay configuration, accessible via `/phd config`.
  * Configuration panel includes controls for anchor position, offsets, font size, number abbreviation toggle, and reset to defaults.

* **Improvements**
  * Migrated configuration from manual slash-command arguments to a user-friendly interface panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->